### PR TITLE
Chore/mvp analysis

### DIFF
--- a/backend/src/controllers/trade.controller.js
+++ b/backend/src/controllers/trade.controller.js
@@ -1,0 +1,59 @@
+import { TradeService } from '../services/trade.service.js';
+
+export class TradeController {
+  static async createTrade(req, res, next) {
+    try {
+      // Assuming req.user is populated by authentication middleware
+      const tradeData = { ...req.body, userId: req.user.id };
+      const newTrade = await TradeService.createTrade(tradeData);
+      res.status(201).json(newTrade);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getTrades(req, res, next) {
+    try {
+      const trades = await TradeService.getTradesByUserId(req.user.id);
+      res.status(200).json(trades);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async getTrade(req, res, next) {
+    try {
+      const trade = await TradeService.getTradeById(req.params.id, req.user.id);
+      if (!trade) {
+        return res.status(404).json({ message: 'Trade not found' });
+      }
+      res.status(200).json(trade);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async updateTrade(req, res, next) {
+    try {
+      const updatedTrade = await TradeService.updateTrade(req.params.id, req.user.id, req.body);
+      if (!updatedTrade) {
+        return res.status(404).json({ message: 'Trade not found' });
+      }
+      res.status(200).json(updatedTrade);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  static async deleteTrade(req, res, next) {
+    try {
+      const success = await TradeService.deleteTrade(req.params.id, req.user.id);
+      if (!success) {
+        return res.status(404).json({ message: 'Trade not found' });
+      }
+      res.status(204).send();
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -26,4 +26,20 @@ export async function initDb() {
       passwordResetExpires DATETIME
     )
   `);
+
+  await db.exec(`
+    CREATE TABLE IF NOT EXISTS trades (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      userId INTEGER NOT NULL,
+      symbol TEXT NOT NULL,
+      direction TEXT NOT NULL,
+      size REAL NOT NULL,
+      entryPrice REAL NOT NULL,
+      exitPrice REAL,
+      notes TEXT,
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (userId) REFERENCES users (id)
+    )
+  `);
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ import session from 'express-session';
 import passport from 'passport';
 import { initDb } from './db.js';
 import authRouter from './routes/auth.routes.js';
+import tradeRouter from './routes/trade.routes.js';
 import errorHandler from './middleware/errorHandler.js';
 import './services/passport.js';
 
@@ -29,6 +30,7 @@ app.get('/', (req, res) => {
 });
 
 app.use('/api/auth', authRouter);
+app.use('/api/trades', tradeRouter);
 
 app.use(errorHandler);
 

--- a/backend/src/middleware/auth.middleware.js
+++ b/backend/src/middleware/auth.middleware.js
@@ -1,0 +1,34 @@
+import jwt from 'jsonwebtoken';
+import { getDb } from '../db.js';
+
+export const protect = async (req, res, next) => {
+  let token;
+
+  if (req.headers.authorization && req.headers.authorization.startsWith('Bearer')) {
+    try {
+      // Get token from header
+      token = req.headers.authorization.split(' ')[1];
+
+      // Verify token
+      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'your_jwt_secret');
+
+      // Get user from the token
+      const db = await getDb();
+      // Select only non-sensitive fields
+      req.user = await db.get('SELECT id, email, name FROM users WHERE id = ?', [decoded.id]);
+
+      if (!req.user) {
+        return res.status(401).json({ message: 'Not authorized, user not found' });
+      }
+
+      next();
+    } catch (error) {
+      console.error(error);
+      res.status(401).json({ message: 'Not authorized, token failed' });
+    }
+  }
+
+  if (!token) {
+    res.status(401).json({ message: 'Not authorized, no token' });
+  }
+};

--- a/backend/src/middleware/validator.js
+++ b/backend/src/middleware/validator.js
@@ -14,13 +14,24 @@ export const loginValidationRules = () => {
   ];
 };
 
+export const tradeValidationRules = () => {
+  return [
+    body('symbol').notEmpty().withMessage('Symbol is required').isString().withMessage('Symbol must be a string'),
+    body('direction').isIn(['buy', 'sell']).withMessage('Direction must be either "buy" or "sell"'),
+    body('size').isFloat({ gt: 0 }).withMessage('Size must be a positive number'),
+    body('entryPrice').isFloat({ gt: 0 }).withMessage('Entry price must be a positive number'),
+    body('exitPrice').optional().isFloat({ gt: 0 }).withMessage('Exit price must be a positive number'),
+    body('notes').optional().isString().withMessage('Notes must be a string'),
+  ];
+};
+
 export const validate = (req, res, next) => {
   const errors = validationResult(req);
   if (errors.isEmpty()) {
     return next();
   }
   const extractedErrors = [];
-  errors.array().map(err => extractedErrors.push({ [err.param]: err.msg }));
+  errors.array().map(err => extractedErrors.push({ [err.path]: err.msg }));
 
   return res.status(422).json({
     errors: extractedErrors,

--- a/backend/src/routes/trade.routes.js
+++ b/backend/src/routes/trade.routes.js
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { TradeController } from '../controllers/trade.controller.js';
+import { protect } from '../middleware/auth.middleware.js';
+import { validate, tradeValidationRules } from '../middleware/validator.js';
+
+const router = Router();
+
+// Protect all routes in this file
+router.use(protect);
+
+router.route('/')
+  .get(TradeController.getTrades)
+  .post(tradeValidationRules(), validate, TradeController.createTrade);
+
+router.route('/:id')
+  .get(TradeController.getTrade)
+  .put(tradeValidationRules(), validate, TradeController.updateTrade)
+  .delete(TradeController.deleteTrade);
+
+export default router;

--- a/backend/src/routes/trades.routes.test.js
+++ b/backend/src/routes/trades.routes.test.js
@@ -1,0 +1,141 @@
+import request from 'supertest';
+import app from '../index.js';
+import { getDb, initDb } from '../db.js';
+import jwt from 'jsonwebtoken';
+
+describe('Trades API', () => {
+  let db;
+  let user;
+  let token;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    await initDb();
+    db = await getDb();
+  });
+
+  beforeEach(async () => {
+    await db.exec('DELETE FROM trades');
+    await db.exec('DELETE FROM users');
+    const userResult = await db.run("INSERT INTO users (email, name, password) VALUES (?, ?, ?)", ['test@example.com', 'Test User', 'password']);
+    user = { id: userResult.lastID, email: 'test@example.com' };
+    token = jwt.sign({ id: user.id }, process.env.JWT_SECRET || 'your_jwt_secret');
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  describe('POST /api/trades', () => {
+    it('should create a new trade for the authenticated user', async () => {
+      const res = await request(app)
+        .post('/api/trades')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          symbol: 'AAPL',
+          direction: 'buy',
+          size: 10,
+          entryPrice: 150.0
+        });
+      expect(res.statusCode).toEqual(201);
+      expect(res.body).toHaveProperty('id');
+      expect(res.body.symbol).toBe('AAPL');
+      expect(res.body.userId).toBe(user.id);
+    });
+
+    it('should return 401 for unauthenticated request', async () => {
+        const res = await request(app)
+          .post('/api/trades')
+          .send({
+            symbol: 'AAPL',
+            direction: 'buy',
+            size: 10,
+            entryPrice: 150.0
+          });
+        expect(res.statusCode).toEqual(401);
+    });
+
+    it('should return 422 for invalid trade data', async () => {
+        const res = await request(app)
+          .post('/api/trades')
+          .set('Authorization', `Bearer ${token}`)
+          .send({
+            symbol: 'AAPL',
+            direction: 'invalid-direction', // Invalid
+            size: -10, // Invalid
+            entryPrice: 150.0
+          });
+        expect(res.statusCode).toEqual(422);
+    });
+  });
+
+  describe('GET /api/trades', () => {
+    it('should get all trades for the user', async () => {
+        await db.run("INSERT INTO trades (userId, symbol, direction, size, entryPrice) VALUES (?, ?, ?, ?, ?)", [user.id, 'GOOG', 'buy', 5, 2800]);
+
+        const res = await request(app)
+            .get('/api/trades')
+            .set('Authorization', `Bearer ${token}`);
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body).toBeInstanceOf(Array);
+        expect(res.body.length).toBe(1);
+        expect(res.body[0].symbol).toBe('GOOG');
+    });
+  });
+
+  describe('PUT /api/trades/:id', () => {
+    it('should update a trade', async () => {
+        const tradeResult = await db.run("INSERT INTO trades (userId, symbol, direction, size, entryPrice) VALUES (?, ?, ?, ?, ?)", [user.id, 'GOOG', 'buy', 5, 2800]);
+        const tradeId = tradeResult.lastID;
+
+        const res = await request(app)
+            .put(`/api/trades/${tradeId}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+              symbol: 'GOOGL',
+              direction: 'buy',
+              size: 5,
+              entryPrice: 2800
+            });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.symbol).toBe('GOOGL');
+    });
+
+    it('should not update a trade of another user', async () => {
+        const otherUserResult = await db.run("INSERT INTO users (email, name) VALUES (?, ?)", ['other@example.com', 'Other User']);
+        const otherUserId = otherUserResult.lastID;
+        const tradeResult = await db.run("INSERT INTO trades (userId, symbol, direction, size, entryPrice) VALUES (?, ?, ?, ?, ?)", [otherUserId, 'TSLA', 'buy', 100, 200]);
+        const tradeId = tradeResult.lastID;
+
+        const res = await request(app)
+            .put(`/api/trades/${tradeId}`)
+            .set('Authorization', `Bearer ${token}`)
+            .send({
+                symbol: 'F',
+                direction: 'buy',
+                size: 100,
+                entryPrice: 200
+            });
+
+        expect(res.statusCode).toEqual(404);
+    });
+  });
+
+  describe('DELETE /api/trades/:id', () => {
+    it('should delete a trade', async () => {
+        const tradeResult = await db.run("INSERT INTO trades (userId, symbol, direction, size, entryPrice) VALUES (?, ?, ?, ?, ?)", [user.id, 'GOOG', 'buy', 5, 2800]);
+        const tradeId = tradeResult.lastID;
+
+        const res = await request(app)
+            .delete(`/api/trades/${tradeId}`)
+            .set('Authorization', `Bearer ${token}`);
+
+        expect(res.statusCode).toEqual(204);
+
+        const dbTrade = await db.get('SELECT * FROM trades WHERE id = ?', tradeId);
+        expect(dbTrade).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/services/trade.service.js
+++ b/backend/src/services/trade.service.js
@@ -1,0 +1,59 @@
+import { getDb } from '../db.js';
+
+export class TradeService {
+  static async createTrade({ userId, symbol, direction, size, entryPrice, exitPrice, notes }) {
+    const db = await getDb();
+    const result = await db.run(
+      'INSERT INTO trades (userId, symbol, direction, size, entryPrice, exitPrice, notes) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [userId, symbol, direction, size, entryPrice, exitPrice, notes]
+    );
+    return { id: result.lastID, userId, symbol, direction, size, entryPrice, exitPrice, notes };
+  }
+
+  static async getTradesByUserId(userId) {
+    const db = await getDb();
+    const trades = await db.all('SELECT * FROM trades WHERE userId = ? ORDER BY createdAt DESC', [userId]);
+    return trades;
+  }
+
+  static async getTradeById(id, userId) {
+    const db = await getDb();
+    const trade = await db.get('SELECT * FROM trades WHERE id = ? AND userId = ?', [id, userId]);
+    return trade;
+  }
+
+  static async updateTrade(id, userId, tradeData) {
+    const db = await getDb();
+    const existingTrade = await this.getTradeById(id, userId);
+    if (!existingTrade) {
+      return null;
+    }
+
+    const updatedTradeData = { ...existingTrade, ...tradeData };
+
+    const result = await db.run(
+      'UPDATE trades SET symbol = ?, direction = ?, size = ?, entryPrice = ?, exitPrice = ?, notes = ?, updatedAt = CURRENT_TIMESTAMP WHERE id = ? AND userId = ?',
+      [
+        updatedTradeData.symbol,
+        updatedTradeData.direction,
+        updatedTradeData.size,
+        updatedTradeData.entryPrice,
+        updatedTradeData.exitPrice,
+        updatedTradeData.notes,
+        id,
+        userId,
+      ]
+    );
+
+    if (result.changes === 0) {
+      return null; // Should not happen if existingTrade was found
+    }
+    return this.getTradeById(id, userId);
+  }
+
+  static async deleteTrade(id, userId) {
+    const db = await getDb();
+    const result = await db.run('DELETE FROM trades WHERE id = ? AND userId = ?', [id, userId]);
+    return result.changes > 0;
+  }
+}

--- a/backend/src/services/trade.service.test.js
+++ b/backend/src/services/trade.service.test.js
@@ -1,0 +1,86 @@
+import { TradeService } from './trade.service.js';
+import { getDb, initDb } from '../db.js';
+import { UserModel } from '../models/user.model.js';
+
+describe('TradeService', () => {
+  let db;
+  let user;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    // It's important to initialize the DB for the test environment
+    await initDb();
+    db = await getDb();
+  });
+
+  beforeEach(async () => {
+    await db.exec('DELETE FROM trades');
+    await db.exec('DELETE FROM users');
+    // Manually insert user since UserModel is not fully fleshed out for testing
+    const userResult = await db.run("INSERT INTO users (email, name) VALUES (?, ?)", ['test@example.com', 'Test User']);
+    user = { id: userResult.lastID, email: 'test@example.com', name: 'Test User' };
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it('should create a new trade', async () => {
+    const tradeData = {
+      userId: user.id,
+      symbol: 'AAPL',
+      direction: 'buy',
+      size: 10,
+      entryPrice: 150.0,
+      notes: 'Test trade'
+    };
+    const trade = await TradeService.createTrade(tradeData);
+    expect(trade).toHaveProperty('id');
+    expect(trade.symbol).toBe('AAPL');
+
+    const dbTrade = await db.get('SELECT * FROM trades WHERE id = ?', trade.id);
+    expect(dbTrade).toBeDefined();
+    expect(dbTrade.symbol).toBe('AAPL');
+  });
+
+  it('should get all trades for a user', async () => {
+    await TradeService.createTrade({ userId: user.id, symbol: 'AAPL', direction: 'buy', size: 10, entryPrice: 150.0 });
+    await TradeService.createTrade({ userId: user.id, symbol: 'GOOG', direction: 'sell', size: 5, entryPrice: 2800.0 });
+
+    const trades = await TradeService.getTradesByUserId(user.id);
+    expect(trades).toHaveLength(2);
+  });
+
+  it('should get a trade by id', async () => {
+    const newTrade = await TradeService.createTrade({ userId: user.id, symbol: 'AAPL', direction: 'buy', size: 10, entryPrice: 150.0 });
+    const foundTrade = await TradeService.getTradeById(newTrade.id, user.id);
+    expect(foundTrade).toBeDefined();
+    expect(foundTrade.id).toBe(newTrade.id);
+  });
+
+  it('should not get a trade belonging to another user', async () => {
+    const newTrade = await TradeService.createTrade({ userId: user.id, symbol: 'AAPL', direction: 'buy', size: 10, entryPrice: 150.0 });
+    const foundTrade = await TradeService.getTradeById(newTrade.id, user.id + 1);
+    expect(foundTrade).toBeUndefined();
+  });
+
+  it('should update a trade with partial data', async () => {
+    const newTrade = await TradeService.createTrade({ userId: user.id, symbol: 'AAPL', direction: 'buy', size: 10, entryPrice: 150.0, notes: 'Original note' });
+    const updatedData = { symbol: 'MSFT', notes: 'Updated note' };
+    const updatedTrade = await TradeService.updateTrade(newTrade.id, user.id, updatedData);
+
+    expect(updatedTrade).toBeDefined();
+    expect(updatedTrade.symbol).toBe('MSFT');
+    expect(updatedTrade.notes).toBe('Updated note');
+    expect(updatedTrade.direction).toBe('buy'); // Should remain unchanged
+  });
+
+  it('should delete a trade', async () => {
+    const newTrade = await TradeService.createTrade({ userId: user.id, symbol: 'AAPL', direction: 'buy', size: 10, entryPrice: 150.0 });
+    const success = await TradeService.deleteTrade(newTrade.id, user.id);
+    expect(success).toBe(true);
+
+    const foundTrade = await TradeService.getTradeById(newTrade.id, user.id);
+    expect(foundTrade).toBeUndefined();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import React, { useState, useEffect } from 'react';
     import ForgotPasswordPage from './pages/ForgotPasswordPage';
     import OAuthCallbackPage from './pages/OAuthCallbackPage';
     import ResetPasswordPage from './pages/ResetPasswordPage';
+import TradesPage from './pages/TradesPage';
     import { LoadingProvider, useLoading } from './components/common/LoadingContext';
     import { ThemeProvider } from './components/common/ThemeContext';
 
@@ -99,6 +100,7 @@ import React, { useState, useEffect } from 'react';
             <Route path="/forgot-password" element={<ForgotPasswordPage />} />
             <Route path="/oauth/callback" element={<OAuthCallbackPage />} />
             <Route path="/reset-password/:token" element={<ResetPasswordPage />} />
+            <Route path="/trades" element={<TradesPage />} />
           </Routes>
           <Footer />
         </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { BookOpen, ChevronDown, Sun, Moon } from 'lucide-react';
 import Button from './common/Button';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTheme } from './common/ThemeContext';
 
 const resourcesLinks = [
@@ -24,6 +24,21 @@ export default function Navbar() {
   const [isResourcesOpen, setIsResourcesOpen] = useState(false);
   const [isFeaturesOpen, setIsFeaturesOpen] = useState(false);
   const { theme, toggleTheme } = useTheme();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      setIsAuthenticated(true);
+    }
+  }, []);
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setIsAuthenticated(false);
+    navigate('/');
+  };
 
   const toggleResources = () => {
     setIsResourcesOpen(!isResourcesOpen);
@@ -81,10 +96,20 @@ export default function Navbar() {
             </div>
             <Link to="/pricing" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">Pricing</Link>
             <Link to="/broker-support" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">Broker Support</Link>
-            <Link to="/login" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">Log In</Link>
-            <Link to="/signup">
-              <Button variant="gradient">Get Started &gt;</Button>
-            </Link>
+
+            {isAuthenticated ? (
+              <>
+                <Link to="/trades" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">My Trades</Link>
+                <Button variant="secondary" onClick={handleLogout}>Logout</Button>
+              </>
+            ) : (
+              <>
+                <Link to="/login" className="text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">Log In</Link>
+                <Link to="/signup">
+                  <Button variant="gradient">Get Started &gt;</Button>
+                </Link>
+              </>
+            )}
           </div>
           <button onClick={toggleTheme} data-testid="theme-switcher" className="p-2 rounded-full text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700">
             {theme === 'light' ? <Moon className="h-6 w-6" /> : <Sun className="h-6 w-6" />}

--- a/src/pages/TradesPage.tsx
+++ b/src/pages/TradesPage.tsx
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+import Button from '../components/common/Button';
+
+// Define a type for the trade object for type safety
+interface Trade {
+  id: number;
+  symbol: string;
+  direction: 'buy' | 'sell';
+  size: number;
+  entryPrice: number;
+  exitPrice?: number;
+  notes?: string;
+  createdAt: string;
+}
+
+const TradesPage: React.FC = () => {
+  const [trades, setTrades] = useState<Trade[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchTrades = async () => {
+      try {
+        setLoading(true);
+        const token = localStorage.getItem('token');
+        if (!token) {
+          setError('No authentication token found. Please log in.');
+          setLoading(false);
+          return;
+        }
+
+        const response = await axios.get('http://localhost:3001/api/trades', {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        setTrades(response.data);
+        setError(null);
+      } catch (err: any) {
+        setError(err.response?.data?.message || 'Failed to fetch trades.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTrades();
+  }, []);
+
+  if (loading) {
+    return <div className="container mx-auto p-4">Loading trades...</div>;
+  }
+
+  if (error) {
+    return <div className="container mx-auto p-4 text-red-500">{error}</div>;
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">My Trades</h1>
+        <Button variant="primary">Add New Trade</Button>
+      </div>
+      <div className="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden">
+        <table className="min-w-full leading-normal">
+          <thead>
+            <tr>
+              <th className="px-5 py-3 border-b-2 border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-700 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">Date</th>
+              <th className="px-5 py-3 border-b-2 border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-700 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">Symbol</th>
+              <th className="px-5 py-3 border-b-2 border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-700 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">Direction</th>
+              <th className="px-5 py-3 border-b-2 border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-700 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">Size</th>
+              <th className="px-5 py-3 border-b-2 border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-700 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">Entry Price</th>
+              <th className="px-5 py-3 border-b-2 border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-700 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">Exit Price</th>
+              <th className="px-5 py-3 border-b-2 border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-700 text-left text-xs font-semibold text-gray-600 dark:text-gray-300 uppercase tracking-wider">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="text-gray-900 dark:text-white">
+            {trades.length > 0 ? (
+              trades.map((trade) => (
+                <tr key={trade.id}>
+                  <td className="px-5 py-5 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">{new Date(trade.createdAt).toLocaleDateString()}</td>
+                  <td className="px-5 py-5 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">{trade.symbol}</td>
+                  <td className="px-5 py-5 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">{trade.direction}</td>
+                  <td className="px-5 py-5 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">{trade.size}</td>
+                  <td className="px-5 py-5 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">{trade.entryPrice}</td>
+                  <td className="px-5 py-5 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">{trade.exitPrice || '-'}</td>
+                  <td className="px-5 py-5 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm">
+                    <Button variant="secondary" size="sm" className="mr-2">Edit</Button>
+                    <Button variant="danger" size="sm">Delete</Button>
+                  </td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={7} className="text-center py-10 text-gray-500 dark:text-gray-400">No trades found.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default TradesPage;

--- a/src/pages/features/TradeAnalysisPage.tsx
+++ b/src/pages/features/TradeAnalysisPage.tsx
@@ -1,24 +1,113 @@
-import React from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
+import axios from 'axios';
 import FeaturePageLayout from './FeaturePageLayout';
+import { Loader } from 'lucide-react';
+
+interface Trade {
+  id: number;
+  symbol: string;
+  direction: 'buy' | 'sell';
+  size: number;
+  entryPrice: number;
+  exitPrice?: number;
+  notes?: string;
+  createdAt: string;
+}
+
+const StatCard: React.FC<{ title: string; value: string | number; className?: string }> = ({ title, value, className }) => (
+  <div className={`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`}>
+    <h3 className="text-lg font-medium text-gray-500 dark:text-gray-400">{title}</h3>
+    <p className="mt-2 text-3xl font-bold text-gray-900 dark:text-white">{value}</p>
+  </div>
+);
 
 export default function TradeAnalysisPage() {
+  const [trades, setTrades] = useState<Trade[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchTrades = async () => {
+      try {
+        const token = localStorage.getItem('token');
+        if (!token) {
+          setError('Please log in to view trade analysis.');
+          setLoading(false);
+          return;
+        }
+        const response = await axios.get('http://localhost:3001/api/trades', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setTrades(response.data);
+      } catch (err) {
+        setError('Failed to fetch trades.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTrades();
+  }, []);
+
+  const metrics = useMemo(() => {
+    const completedTrades = trades.filter(t => t.exitPrice != null && t.exitPrice > 0);
+
+    let totalProfitLoss = 0;
+    let winningTrades = 0;
+    let losingTrades = 0;
+
+    completedTrades.forEach(trade => {
+      const profit = trade.direction === 'buy'
+        ? (trade.exitPrice! - trade.entryPrice) * trade.size
+        : (trade.entryPrice - trade.exitPrice!) * trade.size;
+
+      totalProfitLoss += profit;
+      if (profit > 0) winningTrades++;
+      if (profit < 0) losingTrades++;
+    });
+
+    const totalClosedTrades = winningTrades + losingTrades;
+    const winRate = totalClosedTrades > 0 ? (winningTrades / totalClosedTrades) * 100 : 0;
+
+    return {
+      totalTrades: trades.length,
+      completedTrades: completedTrades.length,
+      totalProfitLoss: totalProfitLoss.toFixed(2),
+      winRate: winRate.toFixed(2),
+      winningTrades,
+      losingTrades,
+    };
+  }, [trades]);
+
+  const renderContent = () => {
+    if (loading) {
+      return <div className="flex justify-center items-center p-10"><Loader className="animate-spin" /> Loading Analysis...</div>;
+    }
+    if (error) {
+      return <div className="text-red-500 text-center p-10">{error}</div>;
+    }
+    if (trades.length === 0) {
+        return <div className="text-center p-10 text-gray-500 dark:text-gray-400">No trades found. Add some trades to see your analysis.</div>;
+    }
+
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <StatCard title="Total Trades" value={metrics.totalTrades} />
+        <StatCard title="Completed Trades" value={metrics.completedTrades} />
+        <StatCard title="Total P/L" value={`$${metrics.totalProfitLoss}`} className={parseFloat(metrics.totalProfitLoss) >= 0 ? 'text-green-500' : 'text-red-500'} />
+        <StatCard title="Win Rate" value={`${metrics.winRate}%`} />
+        <StatCard title="Winning Trades" value={metrics.winningTrades} />
+        <StatCard title="Losing Trades" value={metrics.losingTrades} />
+      </div>
+    );
+  };
+
   return (
     <FeaturePageLayout
       title="Trade Analysis"
       description="Instantly switch between 20 different trading accounts to stay on top of your progress."
       image="/assets/2.png"
     >
-      <div className="bg-white p-6 rounded-lg shadow-md">
-        <h2 className="text-2xl font-bold mb-4">Key Features</h2>
-        <ul className="list-disc list-inside text-gray-600 space-y-2">
-          <li>Performance Metrics: Total profit/loss, win rate, loss rate, etc.</li>
-          <li>Symbol Analysis: Performance metrics for individual symbols.</li>
-          <li>Time-Based Analysis: Performance metrics by day, week, month, or year.</li>
-          <li>Tag-Based Analysis: Performance metrics for trades with specific tags.</li>
-          <li>Risk Analysis: Analysis of risk per trade, risk of ruin calculation.</li>
-          <li>Customizable Analysis: Ability to select specific metrics and time periods.</li>
-        </ul>
-      </div>
+      {renderContent()}
     </FeaturePageLayout>
   );
 }


### PR DESCRIPTION
feat: Implement Trades CRUD and Basic Analysis

This commit introduces the core functionality for managing and analyzing trades, addressing key missing features from the initial MVP audit.

Backend:
- Adds a `trades` table to the SQLite database schema.
- Implements a full CRUD API at `/api/trades` for managing trades.
- Secures the new endpoints with a JWT authentication middleware.
- Adds comprehensive unit and integration tests for the new service and API routes, significantly improving test coverage.
- Implements validation for trade creation and update payloads.

Frontend:
- Creates a new `TradesPage` to list all of a user's trades.
- Updates the `Navbar` to be auth-aware, showing a "My Trades" link and a "Logout" button for authenticated users.
- Transforms the static `TradeAnalysisPage` into a dynamic component that fetches trade data and displays key metrics like P/L and win rate.