### PR TITLE
feat: Add light mode to community forum page

### DIFF
--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -43,19 +43,19 @@ const categories = [
 ];
 
 const LeaderboardItem = ({ user, stat, rank }) => (
-  <div className="flex items-center justify-between p-3 bg-navy-800/50 rounded-lg">
+  <div className="flex items-center justify-between p-3 bg-gray-100 dark:bg-navy-800/50 rounded-lg">
     <div className="flex items-center">
-      <span className="text-sm font-bold text-gray-400 w-6">{rank}.</span>
+      <span className="text-sm font-bold text-gray-500 dark:text-gray-400 w-6">{rank}.</span>
       <img className="h-8 w-8 rounded-full mr-3" src={`https://i.pravatar.cc/40?u=${user}`} alt={user} />
-      <span className="font-medium text-white">{user}</span>
+      <span className="font-medium text-slate-800 dark:text-white">{user}</span>
     </div>
-    <span className="font-semibold text-purple-400">{stat}</span>
+    <span className="font-semibold text-purple-600 dark:text-purple-400">{stat}</span>
   </div>
 );
 
 export default function CommunityPage() {
   return (
-    <div className="forum-bg min-h-screen py-24">
+    <div className="bg-gray-50 dark:forum-bg min-h-screen py-24">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <SectionHeading
           title="Community Hub"
@@ -68,13 +68,13 @@ export default function CommunityPage() {
           <div className="lg:col-span-2">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {categories.map((category) => (
-                <a href={category.link} key={category.name} className="category-card-3d group">
-                  <div className="flex items-center justify-center h-16 w-16 bg-navy-800 rounded-full mb-4 group-hover:scale-110 transition-transform">
+                <a href={category.link} key={category.name} className="bg-white dark:category-card-3d group p-8 rounded-2xl shadow-sm hover:shadow-xl transition-shadow duration-300 flex flex-col items-center text-center">
+                  <div className="flex items-center justify-center h-16 w-16 bg-gray-100 dark:bg-navy-800 rounded-full mb-4 group-hover:scale-110 transition-transform duration-300">
                     {category.icon}
                   </div>
-                  <h3 className="text-xl font-bold text-white mb-2">{category.name}</h3>
-                  <p className="text-gray-400 text-center mb-4">{category.description}</p>
-                  <span className="font-semibold text-purple-400 group-hover:underline">
+                  <h3 className="text-xl font-bold text-slate-800 dark:text-white mb-2">{category.name}</h3>
+                  <p className="text-gray-600 dark:text-gray-400 mb-4 flex-grow">{category.description}</p>
+                  <span className="font-semibold text-purple-600 dark:text-purple-400 group-hover:underline">
                     View Discussions &rarr;
                   </span>
                 </a>
@@ -85,27 +85,27 @@ export default function CommunityPage() {
           {/* Sidebar: Leaderboards & Stats */}
           <div className="space-y-8">
             <div>
-              <h3 className="text-2xl font-bold text-white mb-4">Weekly Leaderboard</h3>
+              <h3 className="text-2xl font-bold text-slate-900 dark:text-white mb-4">Weekly Leaderboard</h3>
               <div className="space-y-3">
-                <h4 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">Most Helpful</h4>
+                <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Most Helpful</h4>
                 <LeaderboardItem user="CryptoGraph" stat="1,204 Upvotes" rank={1} />
                 <LeaderboardItem user="SwingKing" stat="987 Upvotes" rank={2} />
                 <LeaderboardItem user="Anna.T" stat="850 Upvotes" rank={3} />
               </div>
               <div className="mt-6 space-y-3">
-                <h4 className="text-sm font-semibold text-gray-400 uppercase tracking-wider">Top Journals</h4>
+                <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Top Journals</h4>
                 <LeaderboardItem user="RiskManager_01" stat="95% Win Rate" rank={1} />
                 <LeaderboardItem user="ScalperX" stat="12 streak" rank={2} />
                 <LeaderboardItem user="MomentumM" stat="4.5 R:R" rank={3} />
               </div>
             </div>
 
-            <div className="p-6 bg-navy-800/50 rounded-lg">
-              <h3 className="text-xl font-bold text-white mb-3">Community Stats</h3>
+            <div className="p-6 bg-white dark:bg-navy-800/50 rounded-2xl shadow-sm">
+              <h3 className="text-xl font-bold text-slate-900 dark:text-white mb-3">Community Stats</h3>
               <div className="space-y-2">
-                <div className="flex justify-between text-gray-300"><span>Threads:</span><span className="font-semibold">4,821</span></div>
-                <div className="flex justify-between text-gray-300"><span>Posts:</span><span className="font-semibold">62,194</span></div>
-                <div className="flex justify-between text-gray-300"><span>Members:</span><span className="font-semibold">12,345</span></div>
+                <div className="flex justify-between text-gray-700 dark:text-gray-300"><span>Threads:</span><span className="font-semibold">4,821</span></div>
+                <div className="flex justify-between text-gray-700 dark:text-gray-300"><span>Posts:</span><span className="font-semibold">62,194</span></div>
+                <div className="flex justify-between text-gray-700 dark:text-gray-300"><span>Members:</span><span className="font-semibold">12,345</span></div>
               </div>
             </div>
           </div>

--- a/src/pages/Forum.css
+++ b/src/pages/Forum.css
@@ -1,4 +1,4 @@
-.forum-bg {
+.dark .forum-bg {
     background-color: #0a192f; /* A deep navy blue, similar to bg-navy-900 */
     background-image:
       radial-gradient(circle at 15% 50%, rgba(128, 0, 128, 0.1), transparent 30%),
@@ -7,16 +7,9 @@
     background-repeat: no-repeat;
   }
 
-  .category-card-3d {
+  .dark .category-card-3d {
     background-color: rgba(17, 24, 39, 0.6); /* bg-gray-900 with opacity */
     border: 1px solid rgba(75, 85, 99, 0.3); /* gray-700 with opacity */
-    border-radius: 1rem;
-    padding: 2rem;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
@@ -24,7 +17,7 @@
     overflow: hidden;
   }
 
-  .category-card-3d:before {
+  .dark .category-card-3d:before {
     content: '';
     position: absolute;
     top: -50%;
@@ -37,25 +30,11 @@
     pointer-events: none;
   }
 
-  .category-card-3d:hover:before {
+  .dark .category-card-3d:hover:before {
     transform: scale(1);
   }
 
-  .category-card-3d:hover {
+  .dark .category-card-3d:hover {
     transform: translateY(-10px) perspective(1000px) rotateX(2deg);
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4), 0 0 15px rgba(167, 139, 250, 0.2);
-  }
-
-  .leaderboard-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0.75rem;
-    background-color: rgba(31, 41, 55, 0.5); /* bg-gray-800 with opacity */
-    border-radius: 0.5rem;
-    transition: background-color 0.2s ease;
-  }
-
-  .leaderboard-item:hover {
-    background-color: rgba(55, 65, 81, 0.7); /* bg-gray-700 with opacity */
   }


### PR DESCRIPTION
This commit introduces a light theme for the community forum page, making it consistent with the application's theme-switching capabilities.

Changes include:
- Updated `CommunityPage.tsx` with light-mode Tailwind CSS classes and prefixed existing dark-mode classes with `dark:`.
- Refactored `Forum.css` to scope the custom dark-theme styles (gradients, 3D effects) under a `.dark` selector, so they only apply when dark mode is active.

The page now fully supports both light and dark themes.