### PR TITLE
fix: Correct dark mode styling on community page

### DIFF
--- a/src/pages/CommunityPage.tsx
+++ b/src/pages/CommunityPage.tsx
@@ -55,7 +55,7 @@ const LeaderboardItem = ({ user, stat, rank }) => (
 
 export default function CommunityPage() {
   return (
-    <div className="bg-gray-50 dark:forum-bg min-h-screen py-24">
+    <div className="bg-gray-50 forum-bg min-h-screen py-24">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <SectionHeading
           title="Community Hub"
@@ -68,7 +68,7 @@ export default function CommunityPage() {
           <div className="lg:col-span-2">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {categories.map((category) => (
-                <a href={category.link} key={category.name} className="bg-white dark:category-card-3d group p-8 rounded-2xl shadow-sm hover:shadow-xl transition-shadow duration-300 flex flex-col items-center text-center">
+                <a href={category.link} key={category.name} className="bg-white category-card-3d group p-8 rounded-2xl shadow-sm hover:shadow-xl transition-shadow duration-300 flex flex-col items-center text-center">
                   <div className="flex items-center justify-center h-16 w-16 bg-gray-100 dark:bg-navy-800 rounded-full mb-4 group-hover:scale-110 transition-transform duration-300">
                     {category.icon}
                   </div>


### PR DESCRIPTION
The previous implementation of the light/dark theme on the community page had a bug where the dark mode would render with a white background. This was caused by incorrectly using the `dark:` prefix with custom CSS classes.

This commit fixes the issue by removing the `dark:` prefix from the custom classes (`forum-bg`, `category-card-3d`) in `CommunityPage.tsx`. The custom CSS in `Forum.css` is already scoped with a `.dark` parent selector, which is the correct way to apply these styles conditionally. The dark mode now renders correctly.